### PR TITLE
Added CI/CD for lint checking 

### DIFF
--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -1,0 +1,17 @@
+name: Linting Check
+run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Bun
+        run: curl -fsSL https://bun.sh/install | bash
+
+      - name: Run Linter
+        run: bun run lint
+        working-directory: ./

--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -9,9 +9,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install Bun
-        run: curl -fsSL https://bun.sh/install | bash
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
 
       - name: Run Linter
         run: bun run lint
-        working-directory: ./


### PR DESCRIPTION
<img width="1290" height="695" alt="image" src="https://github.com/user-attachments/assets/5e9fb9bc-0fa3-43b0-adf7-4da5d0eea6ad" />

feat: Add GitHub Actions workflow for Bun-based linting

## What you changed:
- Replaced manual Bun installation with official oven-sh/setup-bun@v1 action
- Added dependency installation step (bun install) before running linter


## Why the change was needed:
- Workflow added for checking linting


## Test evidence:
- Workflow now passes without "command not found" errors
- Linting executes successfully in GitHub Actions environment
- All project dependencies are properly installed before lint execution