### PR TITLE
[DEPLOYMENT] Enable MongoDB replica set for local development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,9 @@ services:
   mongodb:
     container_name: mongodb
     image: mongo:latest
+    command: ["mongod", "--replSet", "rs0", "--bind_ip_all"]
     ports:
       - "27017:27017"
-    environment:
-      - MONGO_INITDB_ROOT_USERNAME=admin
-      - MONGO_INITDB_ROOT_PASSWORD=secret
     volumes:
       - mongodb_data:/data/db
 
@@ -27,7 +25,7 @@ services:
       - GITHUB_CALLBACK_URL=http://localhost:8000/oauth/redirect/github
       - GITHUB_OAUTH_CLIENTID=your_client_id
       - GITHUB_OAUTH_SECRET=your_client_secret
-      - DATABASE_URL=mongodb://admin:secret@mongodb:27017/osc-internal?authSource=admin
+      - DATABASE_URL=mongodb://mongodb:27017/osc-internal?replicaSet=rs0
     depends_on:
       - mongodb
 

--- a/project-configuration.md
+++ b/project-configuration.md
@@ -190,7 +190,26 @@ osc-internal-tool-hacktoberFest/
 ### MongoDB
 
 1. Ensure MongoDB is running on `mongodb://127.0.0.1:27017`
-2. Database will be created automatically on first connection
+2. Prisma uses MongoDB transactions, which require MongoDB to run as a **replica set**
+
+### Local Development (Docker)
+
+For local Docker-based setup, MongoDB runs as a **single-node replica set**.
+
+Start services:
+
+```bash
+docker compose up -d
+```
+
+After MongoDB starts, initialize the replica set once:
+
+```bash
+docker exec -it mongodb mongosh
+rs.initiate()
+```
+
+This step is required only once per machine.
 
 ## Verification
 


### PR DESCRIPTION
Fixes #58 

## What changed
- Enabled single-node MongoDB replica set in `docker-compose.yml` for local development
- Removed MongoDB auth from local docker setup
- Added a short note in setup docs `project` explaining replica set requirement

## Why this was needed
Prisma requires MongoDB transactions, which only work when MongoDB runs as a replica set.
Without this, backend write operations fail  & creates confusion for new contributors.

## Notes
- Prisma version remains unchanged (no v7 upgrade)
- Now the project setup via `docker-compose.yml` working successfully
