### PR TITLE
[BACKEND] Fix `this` binding issue in user and team-member route handlers

### DIFF
--- a/apps/server/src/routes/v1/teamMember.route.ts
+++ b/apps/server/src/routes/v1/teamMember.route.ts
@@ -3,17 +3,19 @@ import { Router } from "express";
 
 export const teamMemberRouter = Router();
 
-teamMemberRouter.post("/create", teamMemberController.createTeamMember);
-teamMemberRouter.post(
-  "/remove/by-member-id/:memberId",
-  teamMemberController.removeTeamMember,
+teamMemberRouter.post("/create", (req, res) => 
+  teamMemberController.createTeamMember(req, res),
 );
 teamMemberRouter.post(
-  "/update/by-member-id/:memberId",
-  teamMemberController.updateTeamMember,
+  "/remove/by-member-id/:memberId", (req, res) => 
+  teamMemberController.removeTeamMember(req, res),
+);
+teamMemberRouter.post(
+  "/update/by-member-id/:memberId", (req, res) => 
+  teamMemberController.updateTeamMember(req, res),
 );
 
 teamMemberRouter.get(
-  "/by-team-id/:teamId",
-  teamMemberController.getTeamMembersByTeam,
+  "/by-team-id/:teamId", (req, res) => 
+  teamMemberController.getTeamMembersByTeam(req, res),
 );

--- a/apps/server/src/routes/v1/user.route.ts
+++ b/apps/server/src/routes/v1/user.route.ts
@@ -27,8 +27,14 @@ userRouter.get("/is-authenticated", (req, res) => {
   }
 });
 
-userRouter.post("/signup", userController.handleEmailSignup);
-userRouter.post("/login", userController.handleEmailLogin);
-userRouter.post("/update", userController.updateUserDetails); //incomplete in user.controller
+userRouter.post("/signup", (req, res) => 
+  userController.handleEmailSignup(req, res),
+);
+userRouter.post("/login", (req, res) => 
+  userController.handleEmailLogin(req, res),
+);
+userRouter.post("/update", (req, res) => 
+  userController.updateUserDetails(req, res),
+); //incomplete in user.controller
 
 export default userRouter;


### PR DESCRIPTION
## What this PR does
- Fixes loss of this context in User & Team Member controller methods
- Updates routes to wrap controller calls in arrow functions
- Aligns User & Team Member routes with the existing routing pattern used elsewhere

## Why this is needed
- Passing controller methods directly to Express strips their this context
- This causes runtime failures like this.generateJWT is undefined during login/signup
- Other routes already use safe wrappers, making this inconsistency confusing to debug
- Ensures authentication and team-member APIs work reliably for contributors

## Scope
- User routes (/users/*)
- Team Member routes (/team-members/*)
- Routing layer only (no controller logic changes)

## Testing
Manual testing of:
`POST /api/v1/users/login`
`POST /api/v1/users/signup`
&
Team member routes

Fixes #71 