### PR TITLE
feat(linkedin): add foundational backend data models

### DIFF
--- a/apps/server/src/models/LinkedInAccount.model.ts
+++ b/apps/server/src/models/LinkedInAccount.model.ts
@@ -1,0 +1,17 @@
+export interface LinkedInAccount {
+  id: string;
+
+  // Reference to internal user
+  userId: string;
+
+  // LinkedIn user identifier
+  linkedinUserId: string;
+
+  // OAuth tokens (to be encrypted later)
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt?: Date;
+
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/apps/server/src/models/LinkedInPost.model.ts
+++ b/apps/server/src/models/LinkedInPost.model.ts
@@ -1,0 +1,21 @@
+export type LinkedInPostType = 'TEXT' | 'IMAGE' | 'VIDEO' | 'ARTICLE';
+
+export interface LinkedInPost {
+  id: string;
+
+  // Relation to LinkedInAccount
+  linkedinAccountId: string;
+
+  // LinkedIn post URN
+  postUrn: string;
+
+  postType: LinkedInPostType;
+
+  createdAt: Date;
+
+  // Engagement metrics
+  likesCount: number;
+  commentsCount: number;
+  sharesCount: number;
+  viewsCount?: number;
+}


### PR DESCRIPTION
### Summary
This PR introduces foundational backend data models for LinkedIn integration in Orycon.

### Details
- Adds `LinkedInAccount` model for LinkedIn account associations
- Adds `LinkedInPost` model for normalized post data and engagement metrics

### Notes
A previous PR was closed due to accidentally pushed placeholder files. This PR contains the complete and intended implementation.

Happy to iterate or adjust based on feedback.
