### PR TITLE
chore: add git hooks for prisma generate (post-merge) and next build (pre-push)

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "Post-merge: Generating Prisma client..."
+
+bun run generate:db

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "Pre-push: Checking Next.js build..."
+
+bun run --cwd apps/client build --no-lint


### PR DESCRIPTION
## What this PR does:
- Adds Husky Git hooks to auto-regenerate Prisma client after merges
- Adds a pre-push hook to run Next.js build and block push if build fails

## Why this is needed:
- Prevents Prisma schema/client mismatch after merges
- Avoids pushing code that doesn’t build successfully

## Scope:
- Git hooks only (no API/schema/runtime changes)

## Testing:
- Merge any branch → Prisma client auto-generates
- Push with failing build → push blocked
- Push with passing build → push succeeds

Fixes #77 